### PR TITLE
Fix mapping of methods which have parameter types of String, Date or byte[]

### DIFF
--- a/objectmapper-processor/src/main/java/com/hannesdorfmann/sqlbrite/objectmapper/processor/generator/method/DateMethodCodeGenerator.java
+++ b/objectmapper-processor/src/main/java/com/hannesdorfmann/sqlbrite/objectmapper/processor/generator/method/DateMethodCodeGenerator.java
@@ -23,7 +23,7 @@ public class DateMethodCodeGenerator implements CodeGenerator {
   @Override public void generateAssignStatement(MethodSpec.Builder builder, String objectVarName,
       String cursorVarName, String indexVarName) {
 
-    builder.addStatement("$L.$L( new java.util.Date($L.getLong( $L ) )", objectVarName, method.getMethodName(),
+    builder.addStatement("$L.$L( new java.util.Date($L.getLong( $L ) ) )", objectVarName, method.getMethodName(),
         cursorVarName, indexVarName);
   }
 

--- a/objectmapper-processor/src/main/java/com/hannesdorfmann/sqlbrite/objectmapper/processor/generator/method/MethodCodeFactory.java
+++ b/objectmapper-processor/src/main/java/com/hannesdorfmann/sqlbrite/objectmapper/processor/generator/method/MethodCodeFactory.java
@@ -40,19 +40,19 @@ public class MethodCodeFactory {
         return new MethodCodeGenerator(methodName, "getShort");
 
       case ARRAY:
-        ArrayType arrayType = (ArrayType) element.asType();
-        if (arrayType.getComponentType().getKind() == TypeKind.BYTE) {
+        ArrayType parameterArrayType = (ArrayType) parameter;
+        if (parameterArrayType.getComponentType().getKind() == TypeKind.BYTE) {
           return new MethodCodeGenerator(methodName, "getBlob");
         }
         break;
 
       case DECLARED:
-        String varType = element.asType().toString();
-        if (varType.equals(String.class.getCanonicalName())) {
+        String parameterType = parameter.toString();
+        if (parameterType.equals(String.class.getCanonicalName())) {
           return new MethodCodeGenerator(methodName, "getString");
         }
 
-        if (varType.equals(Date.class.getCanonicalName())) {
+        if (parameterType.equals(Date.class.getCanonicalName())) {
           return new DateMethodCodeGenerator(methodName);
         }
         break;


### PR DESCRIPTION
Previously, an annotated method with a parameter type of String, Date or byte[] would fail with exception.

``` java
@Column(COL_FIRSTNAME)
public void setFirstname(String firstName) {
    this.firstname = firstname;
}
```

```
Error:(38, 15) error: Unsupported type java.lang.String as parameter...
```

This was caused by `MethodCodeFactory` using the method type (return type?) instead of the parameter type.

There was also a closing bracket missing when generating ContentValues builder methods for Date fields.
